### PR TITLE
Fix: Update home image aspect ratio

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "launcher-website",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/src/components/ProjectViewScreenShot/styles.module.css
+++ b/src/components/ProjectViewScreenShot/styles.module.css
@@ -3,38 +3,43 @@
 }
 
 [data-theme='dark'] .projectView__image-mac {
-  max-width: 1704px;
+  max-width: 1010px;
+  aspect-ratio: 1.595;
   background: url(/img/Project_views/mac_screen_project_view_dark.webp);
 }
 
 [data-theme='light'] .projectView__image-mac {
-  max-width: 1704px;
+  max-width: 1010px;
+  aspect-ratio: 1.595;
   background: url(/img/Project_views/mac_screen_project_view_light.webp);
 }
 
 [data-theme='dark'] .projectView__image-linux {
-  max-width: 1052px;
+  max-width: 1010px;
+  aspect-ratio: 1.579;
   background: url(/img/Project_views/linux_screen_project_view_dark.webp);
 }
 
 [data-theme='light'] .projectView__image-linux {
-  max-width: 1052px;
+  max-width: 1010px;
+  aspect-ratio: 1.579;
   background: url(/img/Project_views/linux_screen_project_view_light.webp);
 }
 
 [data-theme='dark'] .projectView__image-windows {
   max-width: 1010px;
+  aspect-ratio: 1.7;
   background: url(/img/Project_views/win_screen_project_view_dark.webp);
 }
 
 [data-theme='light'] .projectView__image-windows {
   max-width: 1010px;
+  aspect-ratio: 1.7;
   background: url(/img/Project_views/win_screen_project_view_light.webp);
 }
 
+
 .projectView .projectView__image {
-  aspect-ratio: 1.49;
-  max-width: 1024px;
   margin: 0 auto;
   background-position: center center;
   background-size: contain;


### PR DESCRIPTION
This pull request includes updates to the version number in `package.json` and modifications to the styles for project view screenshots in `styles.module.css`.

Version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version number from `1.0.0` to `1.0.1`.

Styling changes for project view screenshots:

* [`src/components/ProjectViewScreenShot/styles.module.css`](diffhunk://#diff-ab4792336381a704bbb3f86580994622f4b097c0242ae2703ec32613e4d708b8L6-L37): Adjusted the `max-width` and added `aspect-ratio` properties for images in both dark and light themes for mac, linux, and windows views.