### PR TITLE
Chore: remove issue banner & tag source on deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,6 +39,7 @@ jobs:
     permissions:
       pages: write # to deploy to Pages
       id-token: write # to verify the deployment originates from an appropriate source
+      contents: write # to create a tag
 
     # Deploy to the github-pages environment
     environment:
@@ -50,3 +51,16 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+      
+      - name: Tag the source with package.json version
+        # Only run if the deployment is successful
+        if: success() 
+        run: |
+          VERSION=$(jq -r '.version' package.json)
+          TAG_NAME="v$VERSION"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag $TAG_NAME
+          git push origin $TAG_NAME
+        env:
+          GITHUB_TOKEN: ${{ secrets.SEC_GITHUB_TOKEN }}

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -24,7 +24,7 @@ const config: Config = {
   organizationName: "godotlauncher", // Usually your GitHub org/user name.
   projectName: "launcher-website", // Usually your repo name.
 
-  onBrokenLinks: "warn",
+  onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "warn",
 
   baseUrlIssueBanner: false,

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -27,6 +27,8 @@ const config: Config = {
   onBrokenLinks: "warn",
   onBrokenMarkdownLinks: "warn",
 
+  baseUrlIssueBanner: false,
+
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you
   // may want to replace "en" with "zh-Hans".

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "launcher-website",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "launcher-website",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "dependencies": {
         "@docusaurus/core": "3.7.0",
         "@docusaurus/preset-classic": "3.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "launcher-website",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",


### PR DESCRIPTION
This pull request includes several changes to the deployment workflow and project configuration. The most important changes are related to tagging the source with the package version upon successful deployment, updating the handling of broken links, and incrementing the project version.

Deployment workflow improvements:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R42): Added permissions to write contents and included a step to tag the source with the `package.json` version upon successful deployment. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R42) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R54-R66)

Project configuration updates:

* [`docusaurus.config.ts`](diffhunk://#diff-cc8abb6104e21d495dc8f64639c7b03419226d920d1c545df51be9b0b73b2784L27-R31): Changed `onBrokenLinks` from "warn" to "throw" and added `baseUrlIssueBanner` set to false.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Incremented the project version from `1.1.1` to `1.1.2`.