### PR TITLE
Fix: GitHub pages

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
           cache: 'npm'
 
       - name: Install dependencies

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -28,6 +28,7 @@ const config: Config = {
   onBrokenMarkdownLinks: "warn",
 
   baseUrlIssueBanner: false,
+  trailingSlash: true,
 
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "launcher-website",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "launcher-website",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "dependencies": {
         "@docusaurus/core": "3.7.0",
         "@docusaurus/preset-classic": "3.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "launcher-website",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+godotlauncher.org


### PR DESCRIPTION
This pull request includes several updates to configuration files and versioning. The most important changes are updating the Node.js version in the GitHub Actions workflow, adding a trailing slash configuration to the Docusaurus config, and updating the project version in `package.json`.

Configuration updates:

* [`.github/workflows/test-deploy.yml`](diffhunk://#diff-4632d1836f4abfa2207d2fa36e230837dfe634ab9fcf98fa43f0217d41d4c4a8L20-R20): Updated the Node.js version from 18 to 22 in the GitHub Actions workflow.
* [`docusaurus.config.ts`](diffhunk://#diff-cc8abb6104e21d495dc8f64639c7b03419226d920d1c545df51be9b0b73b2784R31): Added the `trailingSlash` configuration set to `true`.

Versioning update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the project version from `1.1.4` to `1.1.5`.

Domain configuration:

* [`static/CNAME`](diffhunk://#diff-2c4a30f75313bfde8fc686962da9205016ab78ea92e193422b8c5a20a361de5dR1): Added the domain `godotlauncher.org`.