### PR TITLE
Fix: styles and fonts

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -57,7 +57,7 @@
 
 html {
   scroll-behavior: smooth;
-  font-family: "Noto Sans", sans-serif;
+  font-family: "Nunito Sans", sans-serif;
   /* font-size: 18px; */
 }
 

--- a/src/theme/Footer/Copyright/index.module.css
+++ b/src/theme/Footer/Copyright/index.module.css
@@ -1,5 +1,5 @@
 .copyright {
-  font-size: 1.2rem;
+  font-size: 0.9rem;
   text-align: left;
 
   display: flex;
@@ -21,8 +21,8 @@
 }
 
 .disclaimer {
-  font-size: 1rem;
-  opacity: 0.8;
+  font-size: 0.9rem;
+  opacity: 0.6;
   text-align: left;
 
 }


### PR DESCRIPTION
This pull request makes minor stylistic adjustments to the website's font and footer appearance. The changes focus on improving font consistency and refining the footer's layout for better readability.

Typography updates:

* Changed the global font in `src/css/custom.css` from `"Noto Sans"` to `"Nunito Sans"` for improved visual consistency.

Footer style refinements:

* Reduced the font size of the `.copyright` class in `src/theme/Footer/Copyright/index.module.css` from `1.2rem` to `0.9rem` for a more subtle appearance.
* Adjusted the `.disclaimer` class in `src/theme/Footer/Copyright/index.module.css` by lowering the font size from `1rem` to `0.9rem` and decreasing opacity from `0.8` to `0.6`, making it less prominent.